### PR TITLE
Animate on wrong answer - fill-in-the-blank

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "downshift": "7.6.0",
         "eslint": "8.31.0",
         "eslint-config-next": "13.1.2",
+        "framer-motion": "^10.12.4",
         "next": "13.1.2",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -43,6 +44,21 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "optional": true,
+      "dependencies": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "optional": true
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.4.1",
@@ -2018,6 +2034,29 @@
       "funding": {
         "type": "patreon",
         "url": "https://www.patreon.com/infusion"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "10.12.4",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.12.4.tgz",
+      "integrity": "sha512-9gLtv8T6dui0tujHROR+VM3kdJyKiFCFiD94IQE+0OuX6LaIyXtdVpviokVdrHSb1giWhmmX4yzoucALMx6mtw==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "optionalDependencies": {
+        "@emotion/is-prop-valid": "^0.8.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/fs.realpath": {
@@ -4254,6 +4293,21 @@
         "regenerator-runtime": "^0.13.11"
       }
     },
+    "@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "optional": true,
+      "requires": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "optional": true
+    },
     "@eslint/eslintrc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
@@ -5653,6 +5707,15 @@
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
       "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
       "dev": true
+    },
+    "framer-motion": {
+      "version": "10.12.4",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.12.4.tgz",
+      "integrity": "sha512-9gLtv8T6dui0tujHROR+VM3kdJyKiFCFiD94IQE+0OuX6LaIyXtdVpviokVdrHSb1giWhmmX4yzoucALMx6mtw==",
+      "requires": {
+        "@emotion/is-prop-valid": "^0.8.2",
+        "tslib": "^2.4.0"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "downshift": "7.6.0",
     "eslint": "8.31.0",
     "eslint-config-next": "13.1.2",
+    "framer-motion": "^10.12.4",
     "next": "13.1.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/src/components/activities/fill-in-the-blank.tsx
+++ b/src/components/activities/fill-in-the-blank.tsx
@@ -2,6 +2,7 @@ import clsx from "clsx";
 import { useCallback, useMemo, useState } from "react";
 import invariant from "tiny-invariant";
 import { useDraggable, useDroppable } from "../../utils/draggable";
+import { useAnimate, motion, easeIn } from "framer-motion";
 
 type StringifiedQuestion<S extends string> =
   S extends `${infer _}<blank />${infer __}` ? S : never;
@@ -142,7 +143,7 @@ export function FillInTheBlankActivityOption(
         props.isOddI ? "rotate-6" : "-rotate-6",
         isDragging ? "cursor-grabbing" : "cursor-grab",
         isDragging ? "opacity-50" : "opacity-100",
-        "inline-block rounded-lg border-1 border-neutral-600 bg-secondary-100 px-8 py-4 text-base font-medium text-neutral-dark-600 shadow-app-lg shadow-shadow-gray transition-all duration-75 hover:bg-neutral-100"
+        "inline-block rounded-lg border-1 border-neutral-600 bg-secondary-100 px-8 py-4 font-medium text-neutral-dark-600 shadow-app-lg shadow-shadow-gray transition-all duration-75 text-base hover:bg-neutral-100"
       )}
       tabIndex={0}
       onClick={props.onClick}
@@ -161,32 +162,52 @@ export function FillInTheBlankActivityDropZone({
   onClick: () => void;
   selectedOption: ParsedBlankOption | null;
 }) {
+  const [scope, animate] = useAnimate();
   const blankId = props.blank.id;
 
   const [droppableProps] = useDroppable(
     "blank-" + blankId,
     useCallback(
-      (option: ParsedBlankOption, _target: HTMLButtonElement) => {
-        if (option.blankId !== blankId) return;
+      async (option: ParsedBlankOption, _target: HTMLButtonElement) => {
+        if (option.blankId !== blankId || !option.isValid) {
+          const options = { duration: 100 / 1000, transition: easeIn };
+
+          await animate(
+            scope.current,
+            { transform: "translateX(-8px)" },
+            options
+          );
+          await animate(
+            scope.current,
+            { transform: "translateX(8px)" },
+            options
+          );
+          await animate(scope.current, { transform: "translateY(0)" }, options);
+          return;
+        }
 
         onDrop(option);
       },
-      [blankId, onDrop]
+      [animate, blankId, onDrop, scope]
     )
   );
 
   return (
-    <button
-      {...droppableProps}
-      className={clsx(
-        props.selectedOption && "bg-secondary-100 shadow-shadow-gray",
-        !props.selectedOption && "dashed-border-lg",
-        "mx-2 inline-block rounded-lg px-8 py-4 align-middle text-base font-medium shadow-app-lg transition-all duration-75 active:translate-x-1 active:translate-y-1 active:shadow-app-sm"
-      )}
-      onClick={props.onClick}
-    >
-      {props.selectedOption ? props.selectedOption.text : "Fill in the option"}
-    </button>
+    <motion.div ref={scope}>
+      <button
+        {...droppableProps}
+        className={clsx(
+          props.selectedOption && "bg-secondary-100 shadow-shadow-gray",
+          !props.selectedOption && "dashed-border-lg",
+          "mx-2 inline-block rounded-lg px-8 py-4 align-middle font-medium shadow-app-lg transition-all duration-75 text-base active:translate-x-1 active:translate-y-1 active:shadow-app-sm"
+        )}
+        onClick={props.onClick}
+      >
+        {props.selectedOption
+          ? props.selectedOption.text
+          : "Fill in the option"}
+      </button>
+    </motion.div>
   );
 }
 
@@ -253,7 +274,7 @@ export function FillInTheBlankActivity<S extends string>(
 
   return (
     <div className="flex flex-col items-center space-y-9">
-      <p className="max-w-3xl select-none text-center text-4xl font-bold leading-loose text-neutral-dark-700">
+      <p className="max-w-3xl select-none text-center font-bold leading-loose text-neutral-dark-700 text-4xl">
         {questions.map((blank) => {
           if ("text" in blank) {
             return <span key={blank.id}>{blank.text}</span>;


### PR DESCRIPTION
## Summary

This PR implements an animation for wrong options on the fill-in-the-blank activity.

Changes:
- Add `framer-motion` as a dependency.
- Add animation to the blanks when the user drags/clicks the wrong option into it.

## Notes

I'm using a side-to-side animation instead of a top-to-bottom one because web users are used to that for errors (top-to-bottom it's similar to nodding, as in "correct").